### PR TITLE
Add sqlparse to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cx_Oracle
 robotframework
+sqlparse


### PR DESCRIPTION
Added sqlparse to requirement.txt
When installing on a clean python installation sqlparse is not installed.
