### PR TITLE
Accept timeout larger then default timeout

### DIFF
--- a/src/OracleDB.py
+++ b/src/OracleDB.py
@@ -220,7 +220,7 @@ class OracleDB(object):
         if timeouts.get(KeywordTimeout.type, None):
             return timeouts[KeywordTimeout.type]
         test_timeout = timeouts.get(TestTimeout.type, None)
-        return test_timeout if test_timeout and test_timeout < default_timeout else default_timeout
+        return test_timeout if test_timeout and test_timeout else default_timeout
 
     def _replace_parameters_in_statement(self, statement: str, params: Dict[str, Any]) -> str:
         """Update SQL query parameters, if any exist, with their values for logging purposes.


### PR DESCRIPTION
When a testcase/keyword is created  and executes an SQL statement which lasts 20 minutes the following message apears: Timeout is ended and equal as 900.0.

Setting the timeout in the testcase/keyword to 25 minutes ([Timeout]    25 minutes ), to allow the sql to complete does not work, the set "new" timeout is ignored resulting in: Timeout is ended and equal as 900.0.

Fix: Allow all timeouts values even when they are larger then the default_timout when a timeout is set in a testcase/keyword
